### PR TITLE
Crop with x/y values of 0 was not being applied correctly.

### DIFF
--- a/src/Models/Traits/HandlesConversions.php
+++ b/src/Models/Traits/HandlesConversions.php
@@ -53,7 +53,7 @@ trait HandlesConversions
         $conversionFile = SpatieImage::useImageDriver(config('image-library.image_driver'))
             ->loadFile($this->image->getPath());
 
-        if ($this->x || $this->y) {
+        if (isset($this->x) || isset($this->y)) {
             $conversionFile
                 ->manualCrop($this->width, $this->height, $this->x, $this->y);
         } else {


### PR DESCRIPTION
When cropping an image and moving the crop-area to the top left of the image, the crop was not being applied correctly. Instead the crop was being centered again.